### PR TITLE
chore: jenkinx-microservice-nodejs to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.118
 - name: jenkinx-microservice-nodejs
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.6
+  version: 0.0.7
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 5.9.2


### PR DESCRIPTION
chore: Promote jenkinx-microservice-nodejs to version 0.0.7